### PR TITLE
Missing autoloads

### DIFF
--- a/wucuo.el
+++ b/wucuo.el
@@ -412,6 +412,9 @@ Ported from 'https://github.com/fatih/camelcase/blob/master/camelcase.go'."
   (or (derived-mode-p 'nxml-mode)
       (eq major-mode 'web-mode)))
 
+;; Register autoload for markdown-mode.
+(autoload 'markdown-flyspell-check-word-p "markdown-mode")
+
 ;;;###autoload
 (defun wucuo-generic-check-word-predicate ()
   "Function providing per-mode customization over which words are spell checked.

--- a/wucuo.el
+++ b/wucuo.el
@@ -261,16 +261,6 @@ Returns t to continue checking, nil otherwise.")
 (defvar wucuo-timer nil "Internal timer.")
 
 ;;;###autoload
-(defun wucuo-register-extra-typo-detection-algorithms ()
-  "Register extra typo detection algorithms."
-  (autoload 'markdown-flyspell-check-word-p "markdown-mode" nil)
-  (dolist (a wucuo-extra-typo-detection-algorithms)
-    (autoload a (symbol-name a) nil)))
-
-;; register autoload right now
-(wucuo-register-extra-typo-detection-algorithms)
-
-;;;###autoload
 (defun wucuo-current-font-face (&optional quiet)
   "Get font face under cursor.
 If QUIET is t, font face is not output."

--- a/wucuo.el
+++ b/wucuo.el
@@ -90,6 +90,8 @@
 (require 'cl-lib)
 (require 'find-lisp)
 (require 'wucuo-sdk)
+(require 'wucuo-flyspell-html-verify)
+(require 'wucuo-flyspell-org-verify)
 
 (defgroup wucuo nil
   "Code spell checker."


### PR DESCRIPTION
When packaging 0.2.7 for GNU Guix, I the following warning when byte-compiling `wucuo.el`:

``` text
In end of data:
wucuo.el:662:1:Warning: the following functions are not known to be defined:
    wucuo-flyspell-html-verify, wucuo-flyspell-org-verify,
    markdown-flyspell-check-word-p,
    wucuo-flyspell-highlight-incorrect-region-hack
```

I believe this is all a matter of missing autoload declarations.