### PR TITLE
Add instructions for installing via Guix

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,6 +20,9 @@ Screenshot:
 
 * Install
 Wucuo is uploaded to [[http://melpa.org]]. The best way to install is Emacs package manager.
+
+If using [[https://guix.gnu.org/][GNU Guix]], Wucuo and its dependencies can be installed via =guix install emacs-guix=.
+
 * Setup
 Please install either Aspell or Hunspell and the dictionaries at first.
 


### PR DESCRIPTION
A recipe for Wucuo was added to Guix on 2021-05-14:
https://git.savannah.gnu.org/cgit/guix.git/commit/?id=bb94429cb776dc658361e9c26f999c9648d0bd86


----

#